### PR TITLE
drive method now doesn't ignore exceptions but propagates to ErrorRep…

### DIFF
--- a/SharedSequence/src/main/kotlin/org/notests/sharedsequence/DriverTraits.kt
+++ b/SharedSequence/src/main/kotlin/org/notests/sharedsequence/DriverTraits.kt
@@ -5,6 +5,7 @@ import io.reactivex.Observer
 import io.reactivex.Scheduler
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
+import org.notests.sharedsequence.api.ErrorReporting
 import org.notests.sharedsequence.api.SharedSequence
 import org.notests.sharedsequence.api.SharingTrait
 
@@ -20,8 +21,18 @@ object DriverTraits : SharingTrait {
     source.replay(1).refCount()
 }
 
-fun <Element> Driver<Element>.drive(onNext: (Element) -> Unit = {}): Disposable =
-  this.asObservable().subscribe(onNext, {})
+fun <Element> Driver<Element>.drive(onNext: (Element) -> Unit = {}): Disposable = this
+  .asObservable()
+  .subscribe {
+    try {
+      onNext(it)
+    } catch (e: Exception) {
+      ErrorReporting.report(e)
+    }
+  }
 
+/**
+ * Subscribe with a custom observer. Keep in mind that you have to handle errors manually here.
+ */
 fun <Element> Driver<Element>.drive(observer: Observer<Element>): Unit =
   this.asObservable().subscribe(observer)


### PR DESCRIPTION
…orting

Drive method used to ignore errors, now it propagates them to ErrorReporting so that the user can decide what to do with them. 